### PR TITLE
fix: check for status code instead of outdated text when player does not exist

### DIFF
--- a/ovrstat/player_stats.go
+++ b/ovrstat/player_stats.go
@@ -109,7 +109,7 @@ func Stats(platformKey, tag string) (*PlayerStats, error) {
 	}
 
 	// Checks if profile not found, site still returns 200 in this case
-	if pd.Find("[slot=heading]").First().Text() == "Page Not Found" {
+	if pd.Find("[slot=heading]").First().Text() == "Profile Not Found" {
 		return nil, ErrPlayerNotFound
 	}
 

--- a/ovrstat/player_stats.go
+++ b/ovrstat/player_stats.go
@@ -109,7 +109,7 @@ func Stats(platformKey, tag string) (*PlayerStats, error) {
 	}
 
 	// Checks if profile not found, site still returns 200 in this case
-	if pd.Find("[slot=heading]").First().Text() == "Profile Not Found" {
+	if res.StatusCode == http.StatusNotFound {
 		return nil, ErrPlayerNotFound
 	}
 


### PR DESCRIPTION
Currently the detection will fail because the text changed on the website.

Example: https://overwatch.blizzard.com/en-us/career/iusdzbfakjlsdfbjksh-2113/